### PR TITLE
fix: don't reject empty repositoryPath in CategoryMapper.InitializeAsync

### DIFF
--- a/src/MudBlazor.Mcp/Services/Parsing/CategoryMapper.cs
+++ b/src/MudBlazor.Mcp/Services/Parsing/CategoryMapper.cs
@@ -29,7 +29,10 @@ public sealed class CategoryMapper
     /// <returns>A task representing the initialization operation.</returns>
     public Task InitializeAsync(string repositoryPath, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryPath);
+        // Note: repositoryPath is currently unused — categories are hard-coded from MudBlazor's
+        // MenuService. ComponentIndexer passes string.Empty on the cached-load fast path, so we
+        // must not reject empty/whitespace values here.
+        ArgumentNullException.ThrowIfNull(repositoryPath);
 
         if (_isInitialized)
             return Task.CompletedTask;


### PR DESCRIPTION
ComponentIndexer's cached-load fast path intentionally passes string.Empty to CategoryMapper.InitializeAsync (see the comment at ComponentIndexer.cs line 79-81 — "CategoryMapper.InitializeAsync does not currently use the repository path, so we avoid forcing a repository clone/update here to keep the cached path fast and offline-capable").

However, CategoryMapper.InitializeAsync was calling ArgumentException.ThrowIfNullOrWhiteSpace on the parameter, which threw immediately after the cached index was loaded. The exception propagated to Program.cs and produced:

    Failed to build initial index. Server will start without component data.

…leaving the server running but with no components, so all tool calls returned empty results. This also blocks stdio clients from completing the MCP initialize handshake when the failure chain leaves the host in an inconsistent state.

Relax the guard to ArgumentNullException.ThrowIfNull so the cached fast path works as intended. The parameter is currently unused by this method (categories are hard-coded from MudBlazor's MenuService), so dropping the whitespace check is safe; added a comment explaining why for future readers.


The latest stuff is crashing for me. claude made this fix, and now i can use the mcp server. 