### PR TITLE
Update CategoryMapper XML docs and add tests for empty repositoryPath

### DIFF
--- a/src/MudBlazor.Mcp/Services/Parsing/CategoryMapper.cs
+++ b/src/MudBlazor.Mcp/Services/Parsing/CategoryMapper.cs
@@ -29,7 +29,10 @@ public sealed class CategoryMapper
     /// <returns>A task representing the initialization operation.</returns>
     public Task InitializeAsync(string repositoryPath, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(repositoryPath);
+        // Note: repositoryPath is currently unused — categories are hard-coded from MudBlazor's
+        // MenuService. ComponentIndexer passes string.Empty on the cached-load fast path, so we
+        // must not reject empty/whitespace values here.
+        ArgumentNullException.ThrowIfNull(repositoryPath);
 
         if (_isInitialized)
             return Task.CompletedTask;

--- a/src/MudBlazor.Mcp/Services/Parsing/CategoryMapper.cs
+++ b/src/MudBlazor.Mcp/Services/Parsing/CategoryMapper.cs
@@ -22,16 +22,16 @@ public sealed class CategoryMapper
     }
 
     /// <summary>
-    /// Initializes the category mapper from the repository.
+    /// Initializes the category mapper with hard-coded category definitions derived from MudBlazor's MenuService.
     /// </summary>
-    /// <param name="repositoryPath">The path to the MudBlazor repository.</param>
+    /// <param name="repositoryPath">
+    /// The path to the MudBlazor repository. Currently unused because categories are hard-coded.
+    /// May be empty or whitespace (e.g. on the cached-load fast path) but must not be <see langword="null"/>.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the initialization operation.</returns>
     public Task InitializeAsync(string repositoryPath, CancellationToken cancellationToken = default)
     {
-        // Note: repositoryPath is currently unused — categories are hard-coded from MudBlazor's
-        // MenuService. ComponentIndexer passes string.Empty on the cached-load fast path, so we
-        // must not reject empty/whitespace values here.
         ArgumentNullException.ThrowIfNull(repositoryPath);
 
         if (_isInitialized)

--- a/tests/MudBlazor.Mcp.Tests/Parsing/CategoryMapperTests.cs
+++ b/tests/MudBlazor.Mcp.Tests/Parsing/CategoryMapperTests.cs
@@ -109,4 +109,33 @@ public class CategoryMapperTests
         // Assert
         Assert.Null(category);
     }
+
+    [Fact]
+    public async Task InitializeAsync_WithEmptyPath_DoesNotThrow()
+    {
+        // Act & Assert — cached-load fast path passes string.Empty
+        await _mapper.InitializeAsync(string.Empty, CancellationToken.None);
+
+        var categories = _mapper.GetCategories();
+        Assert.NotEmpty(categories);
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("  ")]
+    public async Task InitializeAsync_WithWhitespacePath_DoesNotThrow(string path)
+    {
+        // Act & Assert — whitespace paths are also accepted since repositoryPath is unused
+        await _mapper.InitializeAsync(path, CancellationToken.None);
+
+        var categories = _mapper.GetCategories();
+        Assert.NotEmpty(categories);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithNullPath_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _mapper.InitializeAsync(null!, CancellationToken.None));
+    }
 }


### PR DESCRIPTION
Review feedback on the `InitializeAsync` empty-path relaxation: XML docs still said "from the repository" and no tests covered the new behavior.

- **XML docs**: Updated `InitializeAsync` doc comment to reflect that categories are hard-coded (not loaded from repo) and `repositoryPath` may be empty/whitespace
- **Removed redundant inline comment**: The explanation is now in the XML docs where it belongs
- **Tests**: Added `InitializeAsync_WithEmptyPath_DoesNotThrow`, `InitializeAsync_WithWhitespacePath_DoesNotThrow` (theory: `" "`, `"  "`), and `InitializeAsync_WithNullPath_ThrowsArgumentNullException`